### PR TITLE
add api to get cached model

### DIFF
--- a/app/(protected)/(drawer)/(chat)/new.tsx
+++ b/app/(protected)/(drawer)/(chat)/new.tsx
@@ -13,7 +13,8 @@ import { FlashList } from "@shopify/flash-list";
 import ChatMessage from "@/components/ChatMessage";
 import { useMMKVString } from "react-native-mmkv";
 import { keyStorage, storage } from "@/utils/Storage";
-import { getLlmProvider, getModels, setModel } from "@innobridge/llmclient";
+import { getLlmProvider, getModels, getModel, setModel } from "@innobridge/llmclient";
+import { get } from "react-native/Libraries/TurboModule/TurboModuleRegistry";
 
 const DUMMY_MESSAGES: Message[] = [
     {
@@ -44,9 +45,9 @@ const NewChat = () => {
     const [messages, setMessages] = useState<Message[]>(DUMMY_MESSAGES);
     const [height, setHeight] = useState(0);
     const [llmProvider, setLlmProvider] = useState('');
-
     const [llmModels, setLlmModels] = useState<string[]>([]);
-    const [llmModel, setLlmModel] = useMMKVString('gptVersion', storage);
+    const [currentModel, setCurrentModel] = useState<string | undefined>(undefined);
+
     useEffect(() => {
         const provider = getLlmProvider();
         if (provider === null) {
@@ -54,8 +55,8 @@ const NewChat = () => {
             router.push("/(protected)/(modal)/settings");
         } else {
             setLlmProvider(provider);
+            setCurrentModel(getModel() === null ? undefined : getModel());
             getModels().then((models) => {
-                console.log('Available models: ', models);
                 setLlmModels(models);
             });
         }
@@ -65,7 +66,7 @@ const NewChat = () => {
         return {
             key: model,
             title: model, // You could also format this for better display
-            icon: model===llmModel ? "checkmark" : "sparkles"
+            icon: model === currentModel ? "checkmark" : "sparkles"
         };
     });
 
@@ -86,9 +87,10 @@ const NewChat = () => {
                         <HeaderDropDown 
                             title={llmProvider} 
                             items={getLlmModels}
-                            selected={llmModel}
+                            selected={currentModel}
                             onSelect={(key) => {
-                                setLlmModel(key);
+                                setModel(key);
+                                setCurrentModel(key);
                             }}
                         />
                     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,7 +3275,7 @@
     "node_modules/@innobridge/llmclient": {
       "version": "0.0.0",
       "resolved": "file:../llmclient/innobridge-llmclient-0.0.0.tgz",
-      "integrity": "sha512-4OIvo55i0zELy3u+3zUWJCPtHBP8l+P5phGSxjfTwhKgUp0mUSVfiXetx3zJvq4sE30rr65avcl9W8Q0d28OyA==",
+      "integrity": "sha512-z6NyK9ils4PnLScvbSWsUS1v0WqsxdEtQkYSbVC03GcJeCICrZctTM5Uup1jW0ZhW6NkMwvjvRa/VX8UgI6juA==",
       "license": "InnoBridge",
       "dependencies": {
         "path": "^0.12.7"


### PR DESCRIPTION
This pull request refactors the state management for the currently selected LLM model in the `NewChat` component to improve clarity and consistency. The changes include replacing the use of `useMMKVString` with `useState` for the selected model and ensuring the state is synchronized with the LLM client library.

### State management improvements:

* Replaced `useMMKVString` with `useState` for managing the selected LLM model (`currentModel`) to simplify state handling and avoid direct dependency on MMKV storage. (`app/(protected)/(drawer)/(chat)/new.tsx`, [app/(protected)/(drawer)/(chat)/new.tsxL47-L58](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL47-L58))
* Updated the `icon` property in the model mapping logic to use `currentModel` instead of the previous `llmModel` state. (`app/(protected)/(drawer)/(chat)/new.tsx`, [app/(protected)/(drawer)/(chat)/new.tsxL68-R69](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL68-R69))
* Refactored the `HeaderDropDown` component to use `currentModel` for the `selected` property and updated the `onSelect` callback to synchronize the state with the LLM client library using `setModel`. (`app/(protected)/(drawer)/(chat)/new.tsx`, [app/(protected)/(drawer)/(chat)/new.tsxL89-R93](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL89-R93))

### Code enhancements:

* Added `getModel` import from the LLM client library and initialized `currentModel` state with the result of `getModel()` to ensure consistency with the provider's state. (`app/(protected)/(drawer)/(chat)/new.tsx`, [[1]](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL16-R17) [[2]](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL47-L58)