### PR TITLE
integrate with model object returning back

### DIFF
--- a/app/(protected)/(drawer)/(chat)/new.tsx
+++ b/app/(protected)/(drawer)/(chat)/new.tsx
@@ -69,7 +69,7 @@ const NewChat = () => {
     const getLlmModels = llmModels.map((model: Model) => {
         return {
             key: model.id,
-            title: model.id, // You could also format this for better display
+            title: model.id,
             icon: currentModel && model.id === currentModel.id ? "checkmark" : "sparkles"
         };
     });

--- a/app/(protected)/(drawer)/(chat)/new.tsx
+++ b/app/(protected)/(drawer)/(chat)/new.tsx
@@ -2,7 +2,7 @@
 
 import { View, KeyboardAvoidingView, Platform, StyleSheet, Image } from "react-native"
 import { defaultStyles } from "@/constants/Styles";
-import { Stack, Redirect, useRouter } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import HeaderDropDown from "@/components/HeaderDropDown";
 import { useState, useEffect } from 'react';
 import MessageInput from "@/components/MessageInput";
@@ -11,10 +11,13 @@ import { Message, Role } from "@/utils/Interfaces";
 import Colors from "@/constants/Colors";
 import { FlashList } from "@shopify/flash-list";
 import ChatMessage from "@/components/ChatMessage";
-import { useMMKVString } from "react-native-mmkv";
-import { keyStorage, storage } from "@/utils/Storage";
-import { getLlmProvider, getModels, getModel, setModel } from "@innobridge/llmclient";
-import { get } from "react-native/Libraries/TurboModule/TurboModuleRegistry";
+import { 
+    getLlmProvider, 
+    getModels, 
+    getModel, 
+    setModel,
+    Model
+} from "@innobridge/llmclient";
 
 const DUMMY_MESSAGES: Message[] = [
     {
@@ -45,8 +48,8 @@ const NewChat = () => {
     const [messages, setMessages] = useState<Message[]>(DUMMY_MESSAGES);
     const [height, setHeight] = useState(0);
     const [llmProvider, setLlmProvider] = useState('');
-    const [llmModels, setLlmModels] = useState<string[]>([]);
-    const [currentModel, setCurrentModel] = useState<string | undefined>(undefined);
+    const [llmModels, setLlmModels] = useState<Model[]>([]);
+    const [currentModel, setCurrentModel] = useState<Model | undefined>(undefined);
 
     useEffect(() => {
         const provider = getLlmProvider();
@@ -63,11 +66,11 @@ const NewChat = () => {
         }
     }, [router]);
 
-    const getLlmModels = llmModels.map((model) => {
+    const getLlmModels = llmModels.map((model: Model) => {
         return {
-            key: model,
-            title: model, // You could also format this for better display
-            icon: model === currentModel ? "checkmark" : "sparkles"
+            key: model.id,
+            title: model.id, // You could also format this for better display
+            icon: currentModel && model.id === currentModel.id ? "checkmark" : "sparkles"
         };
     });
 
@@ -88,10 +91,13 @@ const NewChat = () => {
                         <HeaderDropDown 
                             title={llmProvider} 
                             items={getLlmModels}
-                            selected={currentModel}
+                            selected={currentModel && currentModel.id}
                             onSelect={(key) => {
-                                setModel(key);
-                                setCurrentModel(key);
+                                const model = llmModels.find((model) => model.id === key);
+                                if (model) {
+                                    setModel(model);
+                                    setCurrentModel(model);
+                                }
                             }}
                         />
                     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,7 +3275,7 @@
     "node_modules/@innobridge/llmclient": {
       "version": "0.0.0",
       "resolved": "file:../llmclient/innobridge-llmclient-0.0.0.tgz",
-      "integrity": "sha512-z6NyK9ils4PnLScvbSWsUS1v0WqsxdEtQkYSbVC03GcJeCICrZctTM5Uup1jW0ZhW6NkMwvjvRa/VX8UgI6juA==",
+      "integrity": "sha512-r1vh0BGPH5u8VRKtw+tGVeB1teJ3dj01JS9WHCcN3I8HgIerjvvLAU0iZwfVFBT7mtayOpi/S+aawFDiOoPNFg==",
       "license": "InnoBridge",
       "dependencies": {
         "path": "^0.12.7"


### PR DESCRIPTION
This pull request refactors the `NewChat` component in `app/(protected)/(drawer)/(chat)/new.tsx` to improve type safety and enhance the handling of language model data. The key changes include replacing string-based model handling with a strongly-typed `Model` interface, updating related state variables and functions, and cleaning up unused imports.

### Type Safety and Model Handling Improvements:
* Updated state variables `llmModels` and `currentModel` to use the `Model` type instead of plain strings, ensuring stronger type safety and better code clarity.
* Refactored the `getLlmModels` function to map over `Model` objects, using `model.id` for keys and titles, and updated the logic for determining icons based on `Model` properties.
* Modified the `HeaderDropDown` component to handle `Model` objects, ensuring proper selection and updating of the current model by matching `model.id`.

### Code Cleanup:
* Removed unused imports such as `Redirect`, `useMMKVString`, and `keyStorage`, simplifying the import section for better maintainability. [[1]](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL5-R5) [[2]](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL14-R20)