### PR TITLE
hide dalle drawer screen for ollama, ollama doesn't support image gen

### DIFF
--- a/app/(protected)/(drawer)/(chat)/new.tsx
+++ b/app/(protected)/(drawer)/(chat)/new.tsx
@@ -10,7 +10,7 @@ import MessageIdeas from "@/components/MessageIdeas";
 import Colors from "@/constants/Colors";
 import { FlashList } from "@shopify/flash-list";
 import ChatMessage from "@/components/ChatMessage";
-import { api, model, chatRequest, enums, requestMessage, responseMessage } from "@innobridge/llmclient";
+import { api, model, chatRequest, enums, requestMessage } from "@innobridge/llmclient";
 const { getLlmProvider, getModels, getModel, setModel, createCompletion } = api;
 const { Role } = enums;
 

--- a/app/(protected)/(drawer)/_layout.tsx
+++ b/app/(protected)/(drawer)/_layout.tsx
@@ -8,6 +8,10 @@ import { DrawerContentScrollView, DrawerItemList,useDrawerStatus } from '@react-
 import { TextInput } from 'react-native-gesture-handler';
 import { DrawerActions } from '@react-navigation/native';
 import { useEffect } from 'react';
+import { api, configuration } from '@innobridge/llmclient';
+
+const { getLlmProvider } = api;
+const { LlmProvider } = configuration;
 
 export const CustomDrawerContent = (props: any) => {
     const router = useRouter();
@@ -94,6 +98,14 @@ const Layout = () => {
     const dimensions = useWindowDimensions();
     const router = useRouter();
 
+    useEffect(() => {
+        const provider = getLlmProvider();
+        if (provider === null) {
+            console.log('No LLM provider set, redirecting to settings');
+            router.push("/(protected)/(modal)/settings");
+        }
+    }, [router]);
+
     return (
         <Drawer
             drawerContent={CustomDrawerContent}
@@ -169,7 +181,7 @@ const Layout = () => {
                     )
                 }} 
             /> */}
-            <Drawer.Screen 
+             <Drawer.Screen 
                 name='dalle' 
                 options={{
                     title: 'Dall.E',
@@ -180,7 +192,13 @@ const Layout = () => {
                                 style={styles.dallEImage}
                             />
                         </View>
-                    )
+                    ),
+                    drawerItemStyle: {
+                        display:
+                          getLlmProvider() === LlmProvider.OPENAI
+                            ? "flex"
+                            : "none",
+                    },
                 }}
                 listeners={{
                     drawerItemPress: (e) => {

--- a/app/(protected)/(drawer)/dalle.tsx
+++ b/app/(protected)/(drawer)/dalle.tsx
@@ -1,7 +1,8 @@
-import { View, Text } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { defaultStyles } from "@/constants/Styles";
 import HeaderDropDown from "@/components/HeaderDropDown";
 import { Stack } from "expo-router";
+import Colors from "@/constants/Colors";
 
 const Page = () => {
     return (
@@ -23,6 +24,23 @@ const Page = () => {
             />
         </View>
     )
-}
+};
+
+const styles = StyleSheet.create({
+    logoContainer: {
+        alignSelf: 'center',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 50,
+        height: 50,
+        backgroundColor: Colors.black,
+        borderRadius: 50
+    },
+    image: {
+        width: 30,
+        height: 30,
+        resizeMode: 'cover'
+    }
+});
 
 export default Page;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -55,7 +55,7 @@ function InitialLayout() {
     if (isSignedIn && !inAuthGroup) {
       // Bring the user inside
       // router.replace('/(protected)/(drawer)/(chat)/new');
-       router.replace('/(protected)/(drawer)/dalle');
+       router.replace('/(protected)/(drawer)/(chat)/new');
     } else if (!isSignedIn) {
       // Kick the user out
       router.replace('/');


### PR DESCRIPTION
This pull request introduces updates to improve layout behavior, enhance UI styling, and refine imports across several files. The key changes include adding conditional logic for LLM provider settings, introducing new styles for a component, and cleaning up unused imports.

### Layout Behavior Updates:
* [`app/(protected)/(drawer)/_layout.tsx`](diffhunk://#diff-18edbb003007394b5afbd228e6e10a455aeab6319504d4b01ce18b309af03f62R101-R108): Added a `useEffect` hook to redirect users to the settings page if no LLM provider is set. Also, updated `drawerItemStyle` to conditionally display items based on the LLM provider. [[1]](diffhunk://#diff-18edbb003007394b5afbd228e6e10a455aeab6319504d4b01ce18b309af03f62R101-R108) [[2]](diffhunk://#diff-18edbb003007394b5afbd228e6e10a455aeab6319504d4b01ce18b309af03f62L183-R201)

### UI Styling Enhancements:
* [`app/(protected)/(drawer)/dalle.tsx`](diffhunk://#diff-749609a33437dd38973df1c757822d249572de6e069a64d710e8cb5722f3046bR27-R44): Added a new `styles` object to define `logoContainer` and `image` styles, improving UI consistency and maintainability.

### Import Refinements:
* [`app/(protected)/(drawer)/(chat)/new.tsx`](diffhunk://#diff-2e6fbb82d07f83c3058497a198a18e31f16b1fa3e6d8892b2340f1fe181f112fL13-R13): Removed the unused `responseMessage` import from `@innobridge/llmclient`.
* [`app/(protected)/(drawer)/_layout.tsx`](diffhunk://#diff-18edbb003007394b5afbd228e6e10a455aeab6319504d4b01ce18b309af03f62R11-R14): Added imports for `api` and `configuration` from `@innobridge/llmclient` to support new functionality.

### Navigation Adjustment:
* [`app/_layout.tsx`](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L58-R58): Corrected the navigation logic to redirect signed-in users to the chat page instead of the DALL-E page.