### PR TITLE
add generate image feature and display it in chat

### DIFF
--- a/app/(protected)/(drawer)/dalle.tsx
+++ b/app/(protected)/(drawer)/dalle.tsx
@@ -20,27 +20,10 @@ import { ChatMessageProps } from "@/components/ChatMessage";
 const { getLlmProvider, getModel, getModels, setModel } = api;
 const { LlmProvider } = configuration;
 
-const initialMessages: ChatMessageProps[]  = [
-    {
-        role: enums.Role.ASSISTANT,
-        content: "Welcome to DALL-E! What would you like to create today?",
-        imageUrl: "https://galaxies.dev/img/meerkat_2.jpg",
-    },
-    {
-        role: enums.Role.USER,
-        content: "Generate an image of a cat in space",
-    },
-    {
-        role: enums.Role.BOT,
-        content: "Here is your image of a cat in space!",
-        imageUrl: "https://galaxies.dev/img/meerkat_2.jpg",
-    }
-]
-
 const Page = () => {
     const router = useRouter();
     const [height, setHeight] = useState(0);
-    const [messages, setMessages] = useState<ChatMessageProps[]>(initialMessages);
+    const [messages, setMessages] = useState<ChatMessageProps[]>([]);
     const [working, setWorking] = useState(false);
     const [llmProvider, setLlmProvider] = useState('');
     const [llmModels, setLlmModels] = useState<model.Model[]>([]);
@@ -94,7 +77,6 @@ const Page = () => {
 
         setMessages(updatedMessages);
 
-        setCallingImageModel(false);
         const chatRequest: generateImageRequest.GenerateImageRequest = {
             model: currentModel?.id,
             prompt: message,

--- a/app/(protected)/(drawer)/dalle.tsx
+++ b/app/(protected)/(drawer)/dalle.tsx
@@ -1,26 +1,51 @@
-import { View, KeyboardAvoidingView, Platform, StyleSheet, Image } from "react-native";
+import { 
+    View, 
+    KeyboardAvoidingView, 
+    Platform, 
+    StyleSheet, 
+    Image, 
+    Alert 
+} from "react-native";
 import { useState, useEffect } from "react";
 import { defaultStyles } from "@/constants/Styles";
 import HeaderDropDown from "@/components/HeaderDropDown";
 import { Stack, useRouter } from "expo-router";
 import Colors from "@/constants/Colors";
 import { FlashList } from "@shopify/flash-list";
-import { model, api, requestMessage, configuration } from "@innobridge/llmclient";
+import { model, api, configuration, enums, generateImageRequest, imageResponse } from "@innobridge/llmclient";
 import ChatMessage from "@/components/ChatMessage";
 import MessageInput from "@/components/MessageInput";
+import { ChatMessageProps } from "@/components/ChatMessage";
 
 const { getLlmProvider, getModel, getModels, setModel } = api;
 const { LlmProvider } = configuration;
 
+const initialMessages: ChatMessageProps[]  = [
+    {
+        role: enums.Role.ASSISTANT,
+        content: "Welcome to DALL-E! What would you like to create today?",
+        imageUrl: "https://galaxies.dev/img/meerkat_2.jpg",
+    },
+    {
+        role: enums.Role.USER,
+        content: "Generate an image of a cat in space",
+    },
+    {
+        role: enums.Role.BOT,
+        content: "Here is your image of a cat in space!",
+        imageUrl: "https://galaxies.dev/img/meerkat_2.jpg",
+    }
+]
+
 const Page = () => {
     const router = useRouter();
     const [height, setHeight] = useState(0);
-    const [messages, setMessages] = useState<requestMessage.Message[]>([]);
+    const [messages, setMessages] = useState<ChatMessageProps[]>(initialMessages);
     const [working, setWorking] = useState(false);
     const [llmProvider, setLlmProvider] = useState('');
     const [llmModels, setLlmModels] = useState<model.Model[]>([]);
     const [currentModel, setCurrentModel] = useState< model.Model | undefined>(undefined);
-    const [callingLlm, setCallingLlm] = useState(false);
+    const [callingImageModel, setCallingImageModel] = useState(false);
 
     useEffect(() => {
         const provider = getLlmProvider();
@@ -31,8 +56,9 @@ const Page = () => {
             setLlmProvider(provider);
             const model = getModel();
             setCurrentModel(model === null ? undefined : model);
+            const validModels = ["dall-e-3", "dall-e-2", "gpt-image-1"];
             getModels().then((models) => {
-                setLlmModels(models.data);
+                setLlmModels(models.data.filter((model) => validModels.includes(model.id)));
             });
         }
     }, [router]);
@@ -48,6 +74,54 @@ const Page = () => {
     const onLayout = (event: any) => {
         const { height } = event.nativeEvent.layout;
         setHeight(height);
+    };
+
+    const generateImage = async (message: string) => {
+        if (callingImageModel) return;
+        if (getModel() === null) {
+            Alert.alert('Error', 'No model set. Please set the model before sending a message.');
+            return;
+        }
+        if (messages.length === 0) {
+            // Create chat later, store to DB
+        }
+        setCallingImageModel(true);
+
+        const updatedMessages: ChatMessageProps[] = [
+            ...messages, 
+            { content: message, role: enums.Role.USER }
+        ];
+
+        setMessages(updatedMessages);
+
+        setCallingImageModel(false);
+        const chatRequest: generateImageRequest.GenerateImageRequest = {
+            model: currentModel?.id,
+            prompt: message,
+            n: 1,
+            size: enums.ImageSize.SIZE_256x256,
+            response_format: enums.ImageFormat.URL
+        }
+        try {
+
+            const response = await api.generateImage(chatRequest);
+            if (response.data.length > 0) {
+                setMessages((prevMessages) => [
+                    ...prevMessages,
+                    { 
+                        content: "here is yoru message", 
+                        role: enums.Role.BOT,
+                        imageUrl: response.data[0].url
+                    }
+                ]);
+            } else {
+                Alert.alert('Error', 'No image generated. Please try again.');
+            }
+        } catch (error) {
+            Alert.alert('Error', 'Failed to generate image. Please try again.');
+        } finally {
+            setCallingImageModel(false);
+        }
     };
     
     return (
@@ -100,10 +174,10 @@ const Page = () => {
                 {/* {messages.length === 0 && (
                     <MessageIdeas onSelectCard={getCompletion} />
                 )} */}
-                {/* <MessageInput 
-                    disabled={callingLlm}
-                    onShouldSendMessage={getCompletion} 
-                /> */}
+                <MessageInput 
+                    disabled={callingImageModel}
+                    onShouldSendMessage={generateImage} 
+                />
             </KeyboardAvoidingView>
         </View>
     )

--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -6,7 +6,7 @@ import { requestMessage, enums } from '@innobridge/llmclient';
 
 const { Role } = enums;
 
-type ChatMessageProps = requestMessage.Message & {
+export type ChatMessageProps = requestMessage.Message & {
     imageUrl?: string;
     prompt?: string;
 }
@@ -21,7 +21,12 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ content, role, imageUrl, prom
             ) : (
                 <Image source={{ uri: 'https://galaxies.dev/img/meerkat_2.jpg'}} style={styles.avatar} />
             )}
-            <Text style={styles.text}>{content as string}</Text>
+            <View style={styles.contentContainer}>
+                <Text style={styles.text}>{content as string}</Text>
+                {imageUrl && (
+                    <Image source={{ uri: imageUrl }} style={styles.messageImage} />
+                )}
+            </View>
         </View>
     );
 };
@@ -50,11 +55,16 @@ const styles = StyleSheet.create({
         borderRadius: 15,
         backgroundColor: Colors.black
     },
+    contentContainer: {
+        flex: 1,
+        flexDirection: 'column',
+        gap: 8,  // Space between text and image
+    },
     text: {
         padding: 4,
         fontSize: 16,
         flexWrap: 'wrap',
-        flex: 1
+        // flex: 1
     },
     previewImage: {
         width: 40,
@@ -65,6 +75,11 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         height: 26,
         marginLeft: 14
+    },
+    messageImage: {
+        width: 240,
+        height: 240,
+        borderRadius: 10
     }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,7 +3275,7 @@
     "node_modules/@innobridge/llmclient": {
       "version": "0.0.0",
       "resolved": "file:../llmclient/innobridge-llmclient-0.0.0.tgz",
-      "integrity": "sha512-myywrTZiwPeVo5l5+6d0OIGwI3OdtoVmX7fcNFPDxCBceO6nArmy1aUzRgNXKuKdI9DgU3ybL4o7N4wFH1qS9Q==",
+      "integrity": "sha512-QjiHzPxDFiJqlCDUut1kUdaYF6BuUiKGmXOHB0IXLa1dRraXxkopSJuIINowkBzDQujStf0yeRk3l8TxLJGOzw==",
       "license": "InnoBridge",
       "dependencies": {
         "path": "^0.12.7"

--- a/utils/Interfaces.ts
+++ b/utils/Interfaces.ts
@@ -1,14 +1,15 @@
+import { enums } from "@innobridge/llmclient";
 // export enum Role {
 //     User = 0,
 //     Bot = 1
 // }
 
-// export interface Message {
-//     role: Role;
-//     content: string;
-//     imageUrl?: string;
-//     prompt?: string;
-// }
+export interface Message {
+    role: enums.Role;
+    content: string;
+    imageUrl?: string;
+    prompt?: string;
+}
 
 export interface Chat {
     id: number;


### PR DESCRIPTION
This pull request introduces a new feature for generating images using the DALL-E model, along with several enhancements to the `ChatMessage` component and related styles. The changes include integrating image generation functionality, updating the initial message flow, and improving the UI to display generated images.

### New Feature: Image Generation with DALL-E

* Added a `generateImage` function in `dalle.tsx` to handle image generation requests using the DALL-E model. This includes error handling, updating messages, and displaying generated images.
* Introduced a filter for valid models (`dall-e-3`, `dall-e-2`, `gpt-image-1`) when fetching available models.

### Enhancements to `ChatMessage` Component

* Updated `ChatMessage` to display an image (`imageUrl`) alongside the message content if available. Added a new `contentContainer` style for layout adjustments. [[1]](diffhunk://#diff-f0f097304018bdef166332de0251f1190dc16969ae69508844c578197494eee8R24-R29) [[2]](diffhunk://#diff-f0f097304018bdef166332de0251f1190dc16969ae69508844c578197494eee8R58-R67)
* Added a `messageImage` style to define the dimensions and appearance of displayed images.

### Improvements to Initial Message Flow

* Initialized the `messages` state with a predefined set of messages to guide users through the image generation process.

### Code Refactoring and Type Updates

* Exported the `ChatMessageProps` type from `ChatMessage.tsx` for reuse across the app.
* Updated the `Message` interface in `utils/Interfaces.ts` to use `enums.Role` for role definitions, ensuring consistency.

### UI Integration with Image Generation

* Replaced the placeholder `MessageInput` logic with the `generateImage` function, enabling users to send prompts and receive generated images.